### PR TITLE
fixed isupper/islower to behave more like the python equivalent

### DIFF
--- a/graalpython/com.oracle.graal.python.test/src/tests/test_string.py
+++ b/graalpython/com.oracle.graal.python.test/src/tests/test_string.py
@@ -541,6 +541,8 @@ class UnicodeTest(unittest.TestCase):
         self.checkequal(True, 'abc', 'islower')
         self.checkequal(False, 'aBc', 'islower')
         self.checkequal(True, 'abc\n', 'islower')
+        self.checkequal(True, 'a_b!c\n', 'islower')
+        self.checkequal(False, 'A_b!c\n', 'islower')
         self.checkraises(TypeError, 'abc', 'islower', 42)
         self.checkequalnofix(False, '\u1FFc', 'islower')
         self.assertFalse('\u2167'.islower())
@@ -563,6 +565,8 @@ class UnicodeTest(unittest.TestCase):
         self.checkequal(True, 'ABC', 'isupper')
         self.checkequal(False, 'AbC', 'isupper')
         self.checkequal(True, 'ABC\n', 'isupper')
+        self.checkequal(True, 'A_B!C\n', 'isupper')
+        self.checkequal(False, 'a_B!C\n', 'isupper')
         self.checkraises(TypeError, 'abc', 'isupper', 42)
         if not sys.platform.startswith('java'):
             self.checkequalnofix(False, '\u1FFc', 'isupper')

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/str/StringBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/str/StringBuiltins.java
@@ -1805,21 +1805,21 @@ public final class StringBuiltins extends PythonBuiltins {
         @Specialization
         @TruffleBoundary
         boolean doString(String self) {
-            int spaces = 0;
+            int uncased = 0;
             if (self.length() == 0) {
                 return false;
             }
             for (int i = 0; i < self.length(); i++) {
                 int codePoint = self.codePointAt(i);
                 if (!Character.isUpperCase(codePoint)) {
-                    if (Character.isWhitespace(codePoint)) {
-                        spaces++;
+                    if (Character.toLowerCase(codePoint) == Character.toUpperCase(codePoint)) {
+                        uncased++;
                     } else {
                         return false;
                     }
                 }
             }
-            return spaces == 0 || self.length() > spaces;
+            return uncased == 0 || self.length() > uncased;
 
         }
     }

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/str/StringBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/str/StringBuiltins.java
@@ -1691,21 +1691,21 @@ public final class StringBuiltins extends PythonBuiltins {
         @Specialization
         @TruffleBoundary
         boolean doString(String self) {
-            int spaces = 0;
+            int uncased = 0;
             if (self.length() == 0) {
                 return false;
             }
             for (int i = 0; i < self.length(); i++) {
                 int codePoint = self.codePointAt(i);
                 if (!Character.isLowerCase(codePoint)) {
-                    if (Character.isWhitespace(codePoint)) {
-                        spaces++;
+                    if (Character.toLowerCase(codePoint) == Character.toUpperCase(codePoint)) {
+                        uncased++;
                     } else {
                         return false;
                     }
                 }
             }
-            return spaces == 0 || self.length() > spaces;
+            return uncased == 0 || self.length() > uncased;
         }
     }
 


### PR DESCRIPTION
isupper and islower are currently behaving in a way that is not consisten with the standard python implementation.

normally calling isupper on a string like "AF_INET" will return true, but the current implementation will return false.
This fix will ignore all characters that have no upper or lowercase alternative, bringing the implementation closer to the python variant.